### PR TITLE
Remove exclamação quando tem música na frase

### DIFF
--- a/frases.py
+++ b/frases.py
@@ -10,7 +10,7 @@ class Frases:
                 return 'Aumenta o som!'
 
         else:
-            return 'Dia de ouvir ' + artista + ' - ' + musica + '!'
+            return 'Dia de ouvir ' + artista + ' - ' + musica
 
     @staticmethod
     def __diaDaSemana(dia):

--- a/testes/frases_test.py
+++ b/testes/frases_test.py
@@ -2,31 +2,31 @@ from frases import Frases
 from unittest import mock
 
 def test_frase_do_pato_segunda_musica_artista_conhecido():
-    assert Frases.fraseDoPato(0, 'Song 2','Blur') == 'Hoje é Segunda! Dia de ouvir Blur - Song 2!'
+    assert Frases.fraseDoPato(0, 'Song 2','Blur') == 'Hoje é Segunda! Dia de ouvir Blur - Song 2'
 
 
 def test_frase_do_pato_terca_musica_artista_conhecido():
-    assert Frases.fraseDoPato(1, 'songbird', 'oasis') == 'Hoje é Terça! Dia de ouvir oasis - songbird!'
+    assert Frases.fraseDoPato(1, 'songbird', 'oasis') == 'Hoje é Terça! Dia de ouvir oasis - songbird'
 
 
 def test_frase_do_pato_quarta_musica_artista_conhecido():
-    assert Frases.fraseDoPato(2, 'brutal', 'olivia rodrigo') == 'Hoje é Quarta! Dia de ouvir olivia rodrigo - brutal!'
+    assert Frases.fraseDoPato(2, 'brutal', 'olivia rodrigo') == 'Hoje é Quarta! Dia de ouvir olivia rodrigo - brutal'
 
 
 def test_frases_do_pato_quinta_musica_artista_conhecido():
-    assert Frases.fraseDoPato(3, 'song 2', 'blur') == 'Hoje é Quinta! Dia de ouvir blur - song 2!'
+    assert Frases.fraseDoPato(3, 'song 2', 'blur') == 'Hoje é Quinta! Dia de ouvir blur - song 2'
 
 
 def test_frases_do_pato_sexta_musica_artista_conhecido():
-    assert Frases.fraseDoPato(4, 'depois', 'pato fu') == 'Hoje é Sexta! Dia de ouvir pato fu - depois!'
+    assert Frases.fraseDoPato(4, 'depois', 'pato fu') == 'Hoje é Sexta! Dia de ouvir pato fu - depois'
 
 
 def test_frases_do_pato_sabado_musica_artista_conhecido():
-    assert Frases.fraseDoPato(5, 'depois', 'pato fu') == 'Hoje é Sábado! Dia de ouvir pato fu - depois!'
+    assert Frases.fraseDoPato(5, 'depois', 'pato fu') == 'Hoje é Sábado! Dia de ouvir pato fu - depois'
 
 
 def test_frases_do_pato_domingo_musica_artista_conhecido():
-    assert Frases.fraseDoPato(6, 'depois', 'pato fu') == 'Hoje é Domingo! Dia de ouvir pato fu - depois!'
+    assert Frases.fraseDoPato(6, 'depois', 'pato fu') == 'Hoje é Domingo! Dia de ouvir pato fu - depois'
 
 @mock.patch('random.randint')
 def test_frases_do_pato_segunda_musica_desconhecida_bora_dancar(randint_mock):


### PR DESCRIPTION
Remove a exclamação final quando há música na frase do pato.

Ex: `Hoje é Sábado! Dia de ouvir pato fu - depois!` vira `Hoje é Sábado! Dia de ouvir pato fu - depois`

Não remove exclamação quando a música não é encontrada.

`Bora Dançar!` e `Aumenta o Som!`